### PR TITLE
Add nested Dashboard (workspacestopicscards) and ProtectedRoute

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,16 +3,30 @@ import { UserProvider } from "./context/UserContext";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
+import Dashboard from "./pages/Dashboard";
+import ProtectedRoute from "./components/ProtectedRoute";
 
 function App() {
-
   return (
     <UserProvider>
       <Router>
         <Routes>
+          {/* Главная страница — только для авторизованных */}
+          <Route
+            path="/"
+            element={
+              <ProtectedRoute>
+                <Dashboard />
+              </ProtectedRoute>
+            }
+          />
+
+          {/* Аутентификация */}
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
-          {/* другие маршруты */}
+
+          {/* Можно добавить 404 */}
+          <Route path="*" element={<div>Page not found</div>} />
         </Routes>
       </Router>
     </UserProvider>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import type { ReactElement } from "react";
+import { Navigate } from "react-router-dom";
+import { useUser } from "../hooks/useUser";
+
+export default function ProtectedRoute({ children }: { children: ReactElement }) {
+    const { user, loading } = useUser();
+
+    // Пока мы не знаем, залогинен ли пользователь, можно показать спиннер или загрузку:
+    if (loading) {
+        return <div className="p-4 text-center">Loading...</div>;
+    }
+
+    // Если пользователь не авторизован — редирект на страницу входа
+    if (!user) {
+        return <Navigate to="/login" replace />;
+    }
+    // Иначе рендерим переданный компонент
+    return children;
+}

--- a/src/components/Topic.tsx
+++ b/src/components/Topic.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { collection, addDoc, getDocs } from "firebase/firestore";
+import { db } from "../firebase";
+import { useUser } from "../hooks/useUser";
+
+type Card = {
+    id: string;
+    front: string;
+    back: string;
+};
+
+export default function Topic() {
+    const { workspaceId, topicId } = useParams();
+    const { user } = useUser();
+    const [cards, setCards] = useState<Card[]>([]);
+    const [front, setFront] = useState("");
+    const [back, setBack] = useState("");
+
+    useEffect(() => {
+        if (!user || !workspaceId || !topicId) return;
+
+        const fetchCards = async () => {
+            const snapshot = await getDocs(
+                collection(
+                    db,
+                    "users",
+                    user.uid,
+                    "workspaces",
+                    workspaceId,
+                    "topics",
+                    topicId,
+                    "cards"
+                )
+            );
+            const data = snapshot.docs.map((doc) => ({
+                id: doc.id,
+                front: doc.data().front,
+                back: doc.data().back,
+            }));
+            setCards(data);
+        };
+
+        fetchCards();
+    }, [user, workspaceId, topicId]);
+
+    const handleCreateCard = async () => {
+        if (!front.trim() || !back.trim()) return;
+        const ref = collection(
+            db,
+            "users",
+            user.uid,
+            "workspaces",
+            workspaceId!,
+            "topics",
+            topicId!,
+            "cards"
+        );
+        await addDoc(ref, { front, back });
+        setFront("");
+        setBack("");
+        location.reload(); // пока просто перезагружаем страницу
+    };
+
+    return (
+        <div className="p-4 max-w-xl mx-auto">
+            <h1 className="text-xl font-bold mb-4">Cards</h1>
+
+            <div className="space-y-2 mb-4">
+                <input
+                    type="text"
+                    placeholder="Front"
+                    value={front}
+                    onChange={(e) => setFront(e.target.value)}
+                    className="input input-bordered w-full"
+                />
+                <input
+                    type="text"
+                    placeholder="Back"
+                    value={back}
+                    onChange={(e) => setBack(e.target.value)}
+                    className="input input-bordered w-full"
+                />
+                <button onClick={handleCreateCard} className="btn btn-primary w-full">
+                    Add Card
+                </button>
+            </div>
+
+            <ul className="space-y-2">
+                {cards.map((card) => (
+                    <li key={card.id} className="p-2 border rounded">
+                        <strong>{card.front}</strong> → {card.back}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { collection, addDoc, getDocs } from "firebase/firestore";
+import { db } from "../firebase";
+import { useUser } from "../hooks/useUser";
+
+type Topic = {
+    id: string;
+    name: string;
+};
+
+export default function Workspace() {
+    const { workspaceId } = useParams();
+    const { user } = useUser();
+    const [topics, setTopics] = useState<Topic[]>([]);
+    const [name, setName] = useState("");
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (!user || !workspaceId) return;
+
+        const fetchTopics = async () => {
+            const snapshot = await getDocs(
+                collection(db, "users", user.uid, "workspaces", workspaceId, "topics")
+            );
+            const data = snapshot.docs.map((doc) => ({
+                id: doc.id,
+                name: doc.data().name,
+            }));
+            setTopics(data);
+        };
+
+        fetchTopics();
+    }, [user, workspaceId]);
+
+    const handleCreateTopic = async () => {
+        if (!name.trim() || !user || !workspaceId) return;
+        const ref = collection(db, "users", user.uid, "workspaces", workspaceId, "topics");
+        const docRef = await addDoc(ref, { name });
+        navigate(`/workspace/${workspaceId}/topic/${docRef.id}`);
+    };
+
+    return (
+        <div className="p-4 max-w-xl mx-auto">
+            <h1 className="text-xl font-bold mb-4">Topics</h1>
+
+            <div className="flex gap-2 mb-4">
+                <input
+                    type="text"
+                    placeholder="New topic name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className="input input-bordered w-full"
+                />
+                <button onClick={handleCreateTopic} className="btn btn-primary">
+                    Add
+                </button>
+            </div>
+
+            <ul className="space-y-2">
+                {topics.map((topic) => (
+                    <li
+                        key={topic.id}
+                        className="p-2 border rounded cursor-pointer hover:bg-gray-100"
+                        onClick={() => navigate(`/workspace/${workspaceId}/topic/${topic.id}`)}
+                    >
+                        {topic.name}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,7 +1,7 @@
 // src/firebase.ts
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore"; // если используешь Firestore
+import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: "AIzaSyCrqkjbf3G72XMT5zahbSc4w2CQDDQ1ScQ",
@@ -16,4 +16,4 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
-export const db = getFirestore(app); // или getDatabase(app) для Realtime DB
+export const db = getFirestore(app);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,220 @@
+// src/pages/Dashboard.tsx
+import { useEffect, useState } from "react";
+import { db } from "../firebase";
+import { collection, getDocs, addDoc } from "firebase/firestore";
+import { useUser } from "../hooks/useUser";
+
+type Workspace = { id: string; name: string };
+type Topic = { id: string; name: string };
+type Card = { id: string; front: string; back: string };
+
+export default function Dashboard() {
+    const { user } = useUser();
+
+    // 1. State
+    const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+    const [topics, setTopics] = useState<Topic[]>([]);
+    const [cards, setCards] = useState<Card[]>([]);
+
+    const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+    const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
+
+    const [wsName, setWsName] = useState("");
+    const [topicName, setTopicName] = useState("");
+    const [front, setFront] = useState("");
+    const [back, setBack] = useState("");
+
+    // 2. Fetch workspaces
+    useEffect(() => {
+        if (!user) return;
+        const fetchWorkspaces = async () => {
+            const snap = await getDocs(collection(db, "users", user.uid, "workspaces"));
+            setWorkspaces(snap.docs.map(d => ({ id: d.id, name: d.data().name })));
+        };
+        fetchWorkspaces();
+    }, [user]);
+
+    // 3. Fetch topics when a workspace selected
+    useEffect(() => {
+        if (!user || !selectedWorkspaceId) return;
+        const fetchTopics = async () => {
+            const snap = await getDocs(
+                collection(db, "users", user.uid, "workspaces", selectedWorkspaceId, "topics")
+            );
+            setTopics(snap.docs.map(d => ({ id: d.id, name: d.data().name })));
+        };
+        fetchTopics();
+        setSelectedTopicId(null); // сброс темы
+    }, [user, selectedWorkspaceId]);
+
+    // 4. Fetch cards when a topic selected
+    useEffect(() => {
+        if (!user || !selectedWorkspaceId || !selectedTopicId) return;
+        const fetchCards = async () => {
+            const snap = await getDocs(
+                collection(
+                    db,
+                    "users", user.uid,
+                    "workspaces", selectedWorkspaceId,
+                    "topics", selectedTopicId,
+                    "cards"
+                )
+            );
+            setCards(snap.docs.map(d => ({
+                id: d.id,
+                front: d.data().front,
+                back: d.data().back,
+            })));
+        };
+        fetchCards();
+    }, [user, selectedWorkspaceId, selectedTopicId]);
+
+    // 5. Handlers for adding
+    const handleAddWorkspace = async () => {
+        if (!wsName.trim() || !user) return;
+        const ref = collection(db, "users", user.uid, "workspaces");
+        const doc = await addDoc(ref, { name: wsName.trim() });
+        setWsName("");
+        setWorkspaces(prev => [...prev, { id: doc.id, name: wsName.trim() }]);
+    };
+
+    const handleAddTopic = async () => {
+        if (!topicName.trim() || !user || !selectedWorkspaceId) return;
+        const ref = collection(db, "users", user.uid, "workspaces", selectedWorkspaceId, "topics");
+        const doc = await addDoc(ref, { name: topicName.trim() });
+        setTopicName("");
+        setTopics(prev => [...prev, { id: doc.id, name: topicName.trim() }]);
+    };
+
+    const handleAddCard = async () => {
+        if (!front.trim() || !back.trim() || !user || !selectedWorkspaceId || !selectedTopicId) return;
+        const ref = collection(
+            db,
+            "users", user.uid,
+            "workspaces", selectedWorkspaceId,
+            "topics", selectedTopicId,
+            "cards"
+        );
+        const doc = await addDoc(ref, { front: front.trim(), back: back.trim() });
+        setFront("");
+        setBack("");
+        setCards(prev => [...prev, { id: doc.id, front: front.trim(), back: back.trim() }]);
+    };
+
+    // 6. UI
+    return (
+        <div className="p-4 max-w-2xl mx-auto space-y-6">
+            {/* —————— Level 1: Workspaces —————— */}
+            {selectedWorkspaceId === null && (
+                <>
+                    <h2 className="text-2xl font-bold">Workspaces</h2>
+                    <div className="flex gap-2">
+                        <input
+                            value={wsName}
+                            onChange={e => setWsName(e.target.value)}
+                            placeholder="New workspace"
+                            className="input input-bordered flex-grow"
+                        />
+                        <button onClick={handleAddWorkspace} className="btn btn-primary">
+                            Add
+                        </button>
+                    </div>
+                    <ul className="mt-4 space-y-2">
+                        {workspaces.map(ws => (
+                            <li
+                                key={ws.id}
+                                className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
+                                onClick={() => setSelectedWorkspaceId(ws.id)}
+                            >
+                                {ws.name}
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+
+            {/* —————— Level 2: Topics —————— */}
+            {selectedWorkspaceId !== null && selectedTopicId === null && (
+                <>
+                    <button
+                        className="text-sm text-blue-500 mb-2"
+                        onClick={() => setSelectedWorkspaceId(null)}
+                    >
+                        ← Back to Workspaces
+                    </button>
+                    <h2 className="text-2xl font-bold">Topics</h2>
+                    <div className="flex gap-2">
+                        <input
+                            value={topicName}
+                            onChange={e => setTopicName(e.target.value)}
+                            placeholder="New topic"
+                            className="input input-bordered flex-grow"
+                        />
+                        <button onClick={handleAddTopic} className="btn btn-primary">
+                            Add
+                        </button>
+                    </div>
+                    <ul className="mt-4 space-y-2">
+                        {topics.map(t => (
+                            <li
+                                key={t.id}
+                                className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
+                                onClick={() => setSelectedTopicId(t.id)}
+                            >
+                                {t.name}
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+
+            {/* —————— Level 3: Cards —————— */}
+            {selectedWorkspaceId !== null && selectedTopicId !== null && (
+                <>
+                    <div className="flex items-center gap-4 mb-2">
+                        <button
+                            className="text-sm text-blue-500"
+                            onClick={() => setSelectedTopicId(null)}
+                        >
+                            ← Back to Topics
+                        </button>
+                        <button
+                            className="text-sm text-blue-500"
+                            onClick={() => {
+                                setSelectedTopicId(null);
+                                setSelectedWorkspaceId(null);
+                            }}
+                        >
+                            ← Back to Workspaces
+                        </button>
+                    </div>
+                    <h2 className="text-2xl font-bold">Flashcards</h2>
+                    <div className="space-y-2 mb-4">
+                        <input
+                            value={front}
+                            onChange={e => setFront(e.target.value)}
+                            placeholder="Front text"
+                            className="input input-bordered w-full"
+                        />
+                        <input
+                            value={back}
+                            onChange={e => setBack(e.target.value)}
+                            placeholder="Back text"
+                            className="input input-bordered w-full"
+                        />
+                        <button onClick={handleAddCard} className="btn btn-primary w-full">
+                            Add Card
+                        </button>
+                    </div>
+                    <ul className="space-y-2">
+                        {cards.map(c => (
+                            <li key={c.id} className="p-2 border rounded">
+                                <strong>{c.front}</strong> → {c.back}
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
**What’s new**
- Single-page **Dashboard** with three levels:
  1. **Workspaces** (create/select)
  2. **Topics** within a workspace (create/select)
  3. **Cards** within a topic (create)
- Local state & `useEffect` hooks to fetch from Firestore on each level
- `addDoc` + state-updates so new items appear immediately
- **ProtectedRoute** component to guard `/` (Dashboard) behind Firebase Auth

**Why**
This lays the groundwork for all flashcard CRUD operations in one place, without URL changes—just tab-style navigation—and ensures only signed-in users can access their data.

**Next steps**
- Edit & delete operations
- Refactor data-fetching into custom hooks
- UI polish (icons, loading states)
