### PR TITLE
Refactor: extract Firestore logic into hooks; add createdAt + ordered…

### DIFF
--- a/src/hooks/useCards.ts
+++ b/src/hooks/useCards.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  orderBy,
+  serverTimestamp,
+} from "firebase/firestore";
+import { db } from "../firebase";
+import { useUser } from "./useUser";
+import type { Card } from "../types/models";
+
+export function useCards(workspaceId: string | null, topicId: string | null) {
+  const { user } = useUser();
+  const [cards, setCards] = useState<Card[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!user || !workspaceId || !topicId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const q = query(
+        collection(
+          db,
+          "users",
+          user.uid,
+          "workspaces",
+          workspaceId,
+          "topics",
+          topicId,
+          "cards"
+        ),
+        orderBy("createdAt", "asc")
+      );
+      const snap = await getDocs(q);
+      setCards(
+        snap.docs.map((d) => ({
+          id: d.id,
+          front: d.data().front,
+          back: d.data().back,
+          createdAt: d.data().createdAt,
+        }))
+      );
+    } catch (e: any) {
+      setError(e.message ?? "Failed to load cards");
+    } finally {
+      setLoading(false);
+    }
+  }, [user, workspaceId, topicId]);
+
+  useEffect(() => {
+    setCards([]); // reset on selection change
+    void refetch();
+  }, [refetch]);
+
+  const addCard = useCallback(
+    async (front: string, back: string) => {
+      if (!user || !workspaceId || !topicId || !front.trim() || !back.trim())
+        return;
+      const col = collection(
+        db,
+        "users",
+        user.uid,
+        "workspaces",
+        workspaceId,
+        "topics",
+        topicId,
+        "cards"
+      );
+      const docRef = await addDoc(col, {
+        front: front.trim(),
+        back: back.trim(),
+        createdAt: serverTimestamp(),
+      });
+      setCards((prev) => [
+        ...prev,
+        { id: docRef.id, front: front.trim(), back: back.trim() },
+      ]);
+    },
+    [user, workspaceId, topicId]
+  );
+
+  return { cards, loading, error, addCard, refetch };
+}

--- a/src/hooks/useTopics.ts
+++ b/src/hooks/useTopics.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  orderBy,
+  serverTimestamp,
+  doc,
+  updateDoc,
+} from "firebase/firestore";
+import { db } from "../firebase";
+import { useUser } from "./useUser";
+import type { Topic } from "../types/models";
+
+export function useTopics(workspaceId: string | null) {
+  const { user } = useUser();
+  const [topics, setTopics] = useState<Topic[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!user || !workspaceId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const q = query(
+        collection(db, "users", user.uid, "workspaces", workspaceId, "topics"),
+        orderBy("createdAt", "asc")
+      );
+      const snap = await getDocs(q);
+      setTopics(
+        snap.docs.map((d) => ({
+          id: d.id,
+          name: d.data().name,
+          createdAt: d.data().createdAt,
+          progress: d.data().progress ?? 0,
+          lastTrained: d.data().lastTrained,
+        }))
+      );
+    } catch (e: any) {
+      setError(e.message ?? "Failed to load topics");
+    } finally {
+      setLoading(false);
+    }
+  }, [user, workspaceId]);
+
+  useEffect(() => {
+    setTopics([]); // reset on workspace change
+    void refetch();
+  }, [refetch]);
+
+  const addTopic = useCallback(
+    async (name: string) => {
+      if (!user || !workspaceId || !name.trim()) return;
+      const col = collection(
+        db,
+        "users",
+        user.uid,
+        "workspaces",
+        workspaceId,
+        "topics"
+      );
+      const docRef = await addDoc(col, {
+        name: name.trim(),
+        createdAt: serverTimestamp(),
+      });
+      setTopics((prev) => [...prev, { id: docRef.id, name: name.trim() }]);
+    },
+    [user, workspaceId]
+  );
+
+  const updateTopicProgress = useCallback(
+    async (topicId: string, percent: number) => {
+      if (!user || !workspaceId) return;
+      const topicRef = doc(
+        db,
+        "users",
+        user.uid,
+        "workspaces",
+        workspaceId,
+        "topics",
+        topicId
+      );
+      await updateDoc(topicRef, {
+        progress: percent,
+        lastTrained: serverTimestamp(),
+      });
+      // optimistic update
+      setTopics((prev) =>
+        prev.map((t) => (t.id === topicId ? { ...t, progress: percent } : t))
+      );
+    },
+    [user, workspaceId]
+  );
+
+  return { topics, loading, error, addTopic, updateTopicProgress, refetch };
+}

--- a/src/hooks/useWorkspaces.ts
+++ b/src/hooks/useWorkspaces.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  orderBy,
+  serverTimestamp,
+} from "firebase/firestore";
+import { db } from "../firebase";
+import { useUser } from "./useUser";
+import type { Workspace } from "../types/models";
+
+export function useWorkspaces() {
+  const { user } = useUser();
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const q = query(
+        collection(db, "users", user.uid, "workspaces"),
+        orderBy("createdAt", "asc")
+      );
+      const snap = await getDocs(q);
+      setWorkspaces(
+        snap.docs.map((d) => ({
+          id: d.id,
+          name: d.data().name,
+          createdAt: d.data().createdAt,
+        }))
+      );
+    } catch (e: any) {
+      setError(e.message ?? "Failed to load workspaces");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  const addWorkspace = useCallback(
+    async (name: string) => {
+      if (!user || !name.trim()) return;
+      const col = collection(db, "users", user.uid, "workspaces");
+      const docRef = await addDoc(col, {
+        name: name.trim(),
+        createdAt: serverTimestamp(),
+      });
+      // optimistic update
+      setWorkspaces((prev) => [...prev, { id: docRef.id, name: name.trim() }]);
+    },
+    [user]
+  );
+
+  return { workspaces, loading, error, addWorkspace, refetch };
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,103 +1,40 @@
-// src/pages/Dashboard.tsx
-import { useEffect, useState } from "react";
-import { db } from "../firebase";
-import { collection, getDocs, addDoc } from "firebase/firestore";
-import { useUser } from "../hooks/useUser";
+import { useState } from "react";
+import { useWorkspaces } from "../hooks/useWorkspaces";
+import { useTopics } from "../hooks/useTopics";
+import { useCards } from "../hooks/useCards";
 
 import WorkspaceList from "../components/dashboard/workspace/WorkspaceList";
 import TopicList from "../components/dashboard/topic/TopicList";
 import CardList from "../components/dashboard/crds/CardList";
 
-type Workspace = { id: string; name: string };
-type Topic = { id: string; name: string };
-type Card = { id: string; front: string; back: string };
-
 export default function Dashboard() {
-    const { user } = useUser();
-
-    // State
-    const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-    const [topics, setTopics] = useState<Topic[]>([]);
-    const [cards, setCards] = useState<Card[]>([]);
-
+    // selections
     const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
     const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
 
+    // forms
     const [wsName, setWsName] = useState("");
     const [topicName, setTopicName] = useState("");
     const [front, setFront] = useState("");
     const [back, setBack] = useState("");
 
-    // Fetch workspaces
-    useEffect(() => {
-        if (!user) return;
-        (async () => {
-            const snap = await getDocs(collection(db, "users", user.uid, "workspaces"));
-            setWorkspaces(snap.docs.map(d => ({ id: d.id, name: d.data().name })));
-        })();
-    }, [user]);
+    // data via hooks
+    const { workspaces, addWorkspace } = useWorkspaces();
+    const { topics, addTopic } = useTopics(selectedWorkspaceId);
+    const { cards, addCard } = useCards(selectedWorkspaceId, selectedTopicId);
 
-    // Fetch topics
-    useEffect(() => {
-        if (!user || !selectedWorkspaceId) return;
-        (async () => {
-            const snap = await getDocs(
-                collection(db, "users", user.uid, "workspaces", selectedWorkspaceId, "topics")
-            );
-            setTopics(snap.docs.map(d => ({ id: d.id, name: d.data().name })));
-        })();
-        setSelectedTopicId(null);
-    }, [user, selectedWorkspaceId]);
-
-    // Fetch cards
-    useEffect(() => {
-        if (!user || !selectedWorkspaceId || !selectedTopicId) return;
-        (async () => {
-            const snap = await getDocs(
-                collection(
-                    db,
-                    "users", user.uid,
-                    "workspaces", selectedWorkspaceId,
-                    "topics", selectedTopicId,
-                    "cards"
-                )
-            );
-            setCards(snap.docs.map(d => ({
-                id: d.id,
-                front: d.data().front,
-                back: d.data().back,
-            })));
-        })();
-    }, [user, selectedWorkspaceId, selectedTopicId]);
-
-    // Handlers
     const handleAddWorkspace = async () => {
-        if (!wsName.trim() || !user) return;
-        const ref = collection(db, "users", user.uid, "workspaces");
-        const doc = await addDoc(ref, { name: wsName.trim() });
-        setWorkspaces(prev => [...prev, { id: doc.id, name: wsName.trim() }]);
+        await addWorkspace(wsName);
         setWsName("");
     };
 
     const handleAddTopic = async () => {
-        if (!topicName.trim() || !user || !selectedWorkspaceId) return;
-        const ref = collection(db, "users", user.uid, "workspaces", selectedWorkspaceId, "topics");
-        const doc = await addDoc(ref, { name: topicName.trim() });
-        setTopics(prev => [...prev, { id: doc.id, name: topicName.trim() }]);
+        await addTopic(topicName);
         setTopicName("");
     };
 
     const handleAddCard = async () => {
-        if (!front.trim() || !back.trim() || !user || !selectedWorkspaceId || !selectedTopicId) return;
-        const ref = collection(
-            db,
-            "users", user.uid,
-            "workspaces", selectedWorkspaceId,
-            "topics", selectedTopicId,
-            "cards"
-        );
-        const doc = await addDoc(ref, { front: front.trim(), back: back.trim() });
-        setCards(prev => [...prev, { id: doc.id, front: front.trim(), back: back.trim() }]);
+        await addCard(front, back);
         setFront("");
         setBack("");
     };

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,0 +1,20 @@
+export type Workspace = {
+  id: string;
+  name: string;
+  createdAt?: any;
+};
+
+export type Topic = {
+  id: string;
+  name: string;
+  createdAt?: any;
+  progress?: number;
+  lastTrained?: any;
+};
+
+export type Card = {
+  id: string;
+  front: string;
+  back: string;
+  createdAt?: any;
+};


### PR DESCRIPTION
**Summary**
Refactors data access into dedicated hooks and adds deterministic ordering via `createdAt`. Updates pages to use the new hooks.

**What's changed**
- New hooks:
  - `useWorkspaces` (load/add workspaces)
  - `useTopics` (load/add topics; update progress/lastTrained)
  - `useCards` (load/add cards)
- Shared types in `src/types/models.ts`
- `Dashboard` rewritten to consume hooks (no Firestore calls inside UI)
- `TrainingPage` rewritten to consume hooks
- All creates now set `createdAt = serverTimestamp()`
- All reads now use `orderBy('createdAt','asc')`

**Why**
- Clear separation of concerns (auth vs data vs UI)
- Reusable, testable data layer
- Stable, predictable list ordering

**How to test**
1. Create a workspace/topic/card and see it appear at the end of the ordered list.
2. Start a training session, finish it, and verify topic `progress` and `lastTrained` in Firestore.
3. Reload pages: lists keep a stable order.

**Next steps**
- CRUD: edit/delete for workspaces, topics, cards
- Loading/error UI in lists and training
- (Optional) move reads to realtime `onSnapshot`
