### PR TITLE
Feature/crud data hooks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
 import ProtectedRoute from "./components/ProtectedRoute";
+import Training from "./pages/Training";
 
 function App() {
   return (
@@ -24,7 +25,14 @@ function App() {
           {/* Аутентификация */}
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
-
+          <Route
+            path="/training"
+            element={
+              <ProtectedRoute>
+                <Training />
+              </ProtectedRoute>
+            }
+          />
           {/* Можно добавить 404 */}
           <Route path="*" element={<div>Page not found</div>} />
         </Routes>

--- a/src/components/dashboard/crds/CardItem.tsx
+++ b/src/components/dashboard/crds/CardItem.tsx
@@ -1,13 +1,46 @@
+import { useState } from "react";
+
 type Props = {
+    id: string;
     front: string;
     back: string;
+    onUpdate: (id: string, updates: { front?: string; back?: string }) => void;
+    onDelete: (id: string) => void;
 };
 
-export default function CardItem({ front, back }: Props) {
+export default function CardItem({ id, front, back, onUpdate, onDelete }: Props) {
+    const [editing, setEditing] = useState(false);
+    const [f, setF] = useState(front);
+    const [b, setB] = useState(back);
+
     return (
         <li className="p-2 border rounded">
-            <strong>{front}</strong> → {back}
+            {!editing ? (
+                <div className="flex items-center justify-between">
+                    <div>
+                        <strong>{front}</strong> → {back}
+                    </div>
+                    <div className="flex gap-2">
+                        <button className="btn btn-xs" onClick={() => { setF(front); setB(back); setEditing(true); }}>
+                            Edit
+                        </button>
+                        <button className="btn btn-xs btn-error" onClick={() => onDelete(id)}>
+                            Delete
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <div className="space-y-2">
+                    <input className="input input-bordered input-sm w-full" value={f} onChange={(e) => setF(e.target.value)} />
+                    <input className="input input-bordered input-sm w-full" value={b} onChange={(e) => setB(e.target.value)} />
+                    <div className="flex gap-2">
+                        <button className="btn btn-xs btn-primary" onClick={() => { onUpdate(id, { front: f, back: b }); setEditing(false); }}>
+                            Save
+                        </button>
+                        <button className="btn btn-xs" onClick={() => setEditing(false)}>Cancel</button>
+                    </div>
+                </div>
+            )}
         </li>
     );
 }
-

--- a/src/components/dashboard/crds/CardList.tsx
+++ b/src/components/dashboard/crds/CardList.tsx
@@ -9,51 +9,49 @@ type Props = {
     onFrontChange: (s: string) => void;
     onBackChange: (s: string) => void;
     onAdd: () => void;
+    onUpdate: (id: string, updates: { front?: string; back?: string }) => void;
+    onDelete: (id: string) => void;
     onBackTopics: () => void;
     onBackWorkspaces: () => void;
 };
 
 export default function CardList({
-    cards,
-    front,
-    back,
-    onFrontChange,
-    onBackChange,
-    onAdd,
-    onBackTopics,
-    onBackWorkspaces,
+    cards, front, back, onFrontChange, onBackChange, onAdd, onUpdate, onDelete, onBackTopics, onBackWorkspaces
 }: Props) {
     return (
         <>
             <div className="flex items-center gap-4 mb-2">
-                <button className="text-sm text-blue-500" onClick={onBackTopics}>
-                    ← Back to Topics
-                </button>
-                <button className="text-sm text-blue-500" onClick={onBackWorkspaces}>
-                    ← Back to Workspaces
-                </button>
+                <button className="text-sm text-blue-500" onClick={onBackTopics}>← Back to Topics</button>
+                <button className="text-sm text-blue-500" onClick={onBackWorkspaces}>← Back to Workspaces</button>
             </div>
+
             <h2 className="text-2xl font-bold">Flashcards</h2>
             <div className="space-y-2 mb-4">
                 <input
                     value={front}
-                    onChange={e => onFrontChange(e.target.value)}
+                    onChange={(e) => onFrontChange(e.target.value)}
                     placeholder="Front text"
                     className="input input-bordered w-full"
                 />
                 <input
                     value={back}
-                    onChange={e => onBackChange(e.target.value)}
+                    onChange={(e) => onBackChange(e.target.value)}
                     placeholder="Back text"
                     className="input input-bordered w-full"
                 />
-                <button onClick={onAdd} className="btn btn-primary w-full">
-                    Add Card
-                </button>
+                <button onClick={onAdd} className="btn btn-primary w-full">Add Card</button>
             </div>
+
             <ul className="space-y-2">
-                {cards.map(c => (
-                    <CardItem key={c.id} front={c.front} back={c.back} />
+                {cards.map((c) => (
+                    <CardItem
+                        key={c.id}
+                        id={c.id}
+                        front={c.front}
+                        back={c.back}
+                        onUpdate={onUpdate}
+                        onDelete={onDelete}
+                    />
                 ))}
             </ul>
         </>

--- a/src/components/dashboard/topic/TopicItem.tsx
+++ b/src/components/dashboard/topic/TopicItem.tsx
@@ -1,16 +1,44 @@
+import { useState } from "react";
+
 type Props = {
     id: string;
     name: string;
     onSelect: (id: string) => void;
+    onRename: (id: string, newName: string) => void;
+    onDelete: (id: string) => void;
 };
 
-export default function TopicItem({ id, name, onSelect }: Props) {
+export default function TopicItem({ id, name, onSelect, onRename, onDelete }: Props) {
+    const [editing, setEditing] = useState(false);
+    const [value, setValue] = useState(name);
+
     return (
-        <li
-            className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
-            onClick={() => onSelect(id)}
-        >
-            {name}
+        <li className="p-2 border rounded hover:bg-gray-100">
+            {!editing ? (
+                <div className="flex items-center justify-between">
+                    <span className="cursor-pointer" onClick={() => onSelect(id)}>{name}</span>
+                    <div className="flex gap-2">
+                        <button className="btn btn-xs" onClick={() => { setValue(name); setEditing(true); }}>
+                            Edit
+                        </button>
+                        <button className="btn btn-xs btn-error" onClick={() => onDelete(id)}>
+                            Delete
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <div className="flex items-center gap-2">
+                    <input
+                        className="input input-bordered input-sm flex-grow"
+                        value={value}
+                        onChange={(e) => setValue(e.target.value)}
+                    />
+                    <button className="btn btn-xs btn-primary" onClick={() => { onRename(id, value); setEditing(false); }}>
+                        Save
+                    </button>
+                    <button className="btn btn-xs" onClick={() => setEditing(false)}>Cancel</button>
+                </div>
+            )}
         </li>
     );
 }

--- a/src/components/dashboard/topic/TopicList.tsx
+++ b/src/components/dashboard/topic/TopicList.tsx
@@ -8,40 +8,40 @@ type Props = {
     onNameChange: (s: string) => void;
     onAdd: () => void;
     onSelect: (id: string) => void;
+    onRename: (id: string, newName: string) => void;
+    onDelete: (id: string) => void;
     onBack: () => void;
 };
 
 export default function TopicList({
-    topics,
-    newName,
-    onNameChange,
-    onAdd,
-    onSelect,
-    onBack,
+    topics, newName, onNameChange, onAdd, onSelect, onRename, onDelete, onBack
 }: Props) {
     return (
         <>
-            <button
-                className="text-sm text-blue-500 mb-2"
-                onClick={onBack}
-            >
+            <button className="text-sm text-blue-500 mb-2" onClick={onBack}>
                 ← Back to Workspaces
             </button>
             <h2 className="text-2xl font-bold">Topics</h2>
             <div className="flex gap-2">
                 <input
                     value={newName}
-                    onChange={e => onNameChange(e.target.value)}
+                    onChange={(e) => onNameChange(e.target.value)}
                     placeholder="New topic"
                     className="input input-bordered flex-grow"
                 />
-                <button onClick={onAdd} className="btn btn-primary">
-                    Add
-                </button>
+                <button onClick={onAdd} className="btn btn-primary">Add</button>
             </div>
+
             <ul className="mt-4 space-y-2">
-                {topics.map(t => (
-                    <TopicItem key={t.id} id={t.id} name={t.name} onSelect={onSelect} />
+                {topics.map((t) => (
+                    <TopicItem
+                        key={t.id}
+                        id={t.id}
+                        name={t.name}
+                        onSelect={onSelect}
+                        onRename={onRename}
+                        onDelete={onDelete}
+                    />
                 ))}
             </ul>
         </>

--- a/src/components/dashboard/workspace/WorkspaceItem.tsx
+++ b/src/components/dashboard/workspace/WorkspaceItem.tsx
@@ -1,16 +1,49 @@
+import { useState } from "react";
+
 type Props = {
     id: string;
     name: string;
     onSelect: (id: string) => void;
+    onRename: (id: string, newName: string) => void;
+    onDelete: (id: string) => void;
 };
 
-export default function WorkspaceItem({ id, name, onSelect }: Props) {
+export default function WorkspaceItem({ id, name, onSelect, onRename, onDelete }: Props) {
+    const [editing, setEditing] = useState(false);
+    const [value, setValue] = useState(name);
+
     return (
-        <li
-            className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
-            onClick={() => onSelect(id)}
-        >
-            {name}
+        <li className="p-2 border rounded hover:bg-gray-100">
+            {!editing ? (
+                <div className="flex items-center justify-between">
+                    <span className="cursor-pointer" onClick={() => onSelect(id)}>{name}</span>
+                    <div className="flex gap-2">
+                        <button className="btn btn-xs" onClick={() => { setValue(name); setEditing(true); }}>
+                            Edit
+                        </button>
+                        <button className="btn btn-xs btn-error" onClick={() => onDelete(id)}>
+                            Delete
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <div className="flex items-center gap-2">
+                    <input
+                        className="input input-bordered input-sm flex-grow"
+                        value={value}
+                        onChange={(e) => setValue(e.target.value)}
+                    />
+                    <button
+                        className="btn btn-xs btn-primary"
+                        onClick={() => { onRename(id, value); setEditing(false); }}
+                    >
+                        Save
+                    </button>
+                    <button className="btn btn-xs" onClick={() => setEditing(false)}>
+                        Cancel
+                    </button>
+                </div>
+            )}
         </li>
     );
 }

--- a/src/components/dashboard/workspace/WorkspaceList.tsx
+++ b/src/components/dashboard/workspace/WorkspaceList.tsx
@@ -8,14 +8,12 @@ type Props = {
     onNameChange: (s: string) => void;
     onAdd: () => void;
     onSelect: (id: string) => void;
+    onRename: (id: string, newName: string) => void;
+    onDelete: (id: string) => void;
 };
 
 export default function WorkspaceList({
-    workspaces,
-    newName,
-    onNameChange,
-    onAdd,
-    onSelect,
+    workspaces, newName, onNameChange, onAdd, onSelect, onRename, onDelete
 }: Props) {
     return (
         <>
@@ -23,21 +21,22 @@ export default function WorkspaceList({
             <div className="flex gap-2">
                 <input
                     value={newName}
-                    onChange={e => onNameChange(e.target.value)}
+                    onChange={(e) => onNameChange(e.target.value)}
                     placeholder="New workspace"
                     className="input input-bordered flex-grow"
                 />
-                <button onClick={onAdd} className="btn btn-primary">
-                    Add
-                </button>
+                <button onClick={onAdd} className="btn btn-primary">Add</button>
             </div>
+
             <ul className="mt-4 space-y-2">
-                {workspaces.map(ws => (
+                {workspaces.map((ws) => (
                     <WorkspaceItem
                         key={ws.id}
                         id={ws.id}
                         name={ws.name}
                         onSelect={onSelect}
+                        onRename={onRename}
+                        onDelete={onDelete}
                     />
                 ))}
             </ul>

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,16 +1,40 @@
-// src/firebase.ts
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
+// В Vite все env читаем через import.meta.env.*
+// Оборачиваем в небольшую проверку, чтобы ловить опечатки.
+function required(name: string, value: string | undefined) {
+  if (!value) throw new Error(`Missing env var: ${name}`);
+  return value;
+}
+
 const firebaseConfig = {
-  apiKey: "AIzaSyCrqkjbf3G72XMT5zahbSc4w2CQDDQ1ScQ",
-  authDomain: "flashcards-learning-app-d6270.firebaseapp.com",
-  projectId: "flashcards-learning-app-d6270",
-  storageBucket: "flashcards-learning-app-d6270.firebasestorage.app",
-  messagingSenderId: "1071481356924",
-  appId: "1:1071481356924:web:c2b996c49bcc351ffe7ff9",
-  measurementId: "G-P6EQMHKKVY",
+  apiKey: required(
+    "VITE_FIREBASE_API_KEY",
+    import.meta.env.VITE_FIREBASE_API_KEY
+  ),
+  authDomain: required(
+    "VITE_FIREBASE_AUTH_DOMAIN",
+    import.meta.env.VITE_FIREBASE_AUTH_DOMAIN
+  ),
+  projectId: required(
+    "VITE_FIREBASE_PROJECT_ID",
+    import.meta.env.VITE_FIREBASE_PROJECT_ID
+  ),
+  storageBucket: required(
+    "VITE_FIREBASE_STORAGE_BUCKET",
+    import.meta.env.VITE_FIREBASE_STORAGE_BUCKET
+  ),
+  messagingSenderId: required(
+    "VITE_FIREBASE_MESSAGING_SENDER_ID",
+    import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID
+  ),
+  appId: required("VITE_FIREBASE_APP_ID", import.meta.env.VITE_FIREBASE_APP_ID),
+  // measurementId не обязателен для работы
+  ...(import.meta.env.VITE_FIREBASE_MEASUREMENT_ID
+    ? { measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID }
+    : {}),
 };
 
 const app = initializeApp(firebaseConfig);

--- a/src/hooks/useCards.ts
+++ b/src/hooks/useCards.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  orderBy,
+  serverTimestamp,
+} from "firebase/firestore";
+import { db } from "../firebase";
+import { useUser } from "./useUser";
+import type { Card } from "../types/models";
+
+export function useCards(workspaceId: string | null, topicId: string | null) {
+  const { user } = useUser();
+  const [cards, setCards] = useState<Card[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!user || !workspaceId || !topicId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const q = query(
+        collection(
+          db,
+          "users",
+          user.uid,
+          "workspaces",
+          workspaceId,
+          "topics",
+          topicId,
+          "cards"
+        ),
+        orderBy("createdAt", "asc")
+      );
+      const snap = await getDocs(q);
+      setCards(
+        snap.docs.map((d) => ({
+          id: d.id,
+          front: d.data().front,
+          back: d.data().back,
+          createdAt: d.data().createdAt,
+        }))
+      );
+    } catch (e: any) {
+      setError(e.message ?? "Failed to load cards");
+    } finally {
+      setLoading(false);
+    }
+  }, [user, workspaceId, topicId]);
+
+  useEffect(() => {
+    setCards([]); // reset on selection change
+    void refetch();
+  }, [refetch]);
+
+  const addCard = useCallback(
+    async (front: string, back: string) => {
+      if (!user || !workspaceId || !topicId || !front.trim() || !back.trim())
+        return;
+      const col = collection(
+        db,
+        "users",
+        user.uid,
+        "workspaces",
+        workspaceId,
+        "topics",
+        topicId,
+        "cards"
+      );
+      const docRef = await addDoc(col, {
+        front: front.trim(),
+        back: back.trim(),
+        createdAt: serverTimestamp(),
+      });
+      setCards((prev) => [
+        ...prev,
+        { id: docRef.id, front: front.trim(), back: back.trim() },
+      ]);
+    },
+    [user, workspaceId, topicId]
+  );
+
+  return { cards, loading, error, addCard, refetch };
+}

--- a/src/hooks/useTopics.ts
+++ b/src/hooks/useTopics.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  orderBy,
+  serverTimestamp,
+  doc,
+  updateDoc,
+} from "firebase/firestore";
+import { db } from "../firebase";
+import { useUser } from "./useUser";
+import type { Topic } from "../types/models";
+
+export function useTopics(workspaceId: string | null) {
+  const { user } = useUser();
+  const [topics, setTopics] = useState<Topic[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!user || !workspaceId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const q = query(
+        collection(db, "users", user.uid, "workspaces", workspaceId, "topics"),
+        orderBy("createdAt", "asc")
+      );
+      const snap = await getDocs(q);
+      setTopics(
+        snap.docs.map((d) => ({
+          id: d.id,
+          name: d.data().name,
+          createdAt: d.data().createdAt,
+          progress: d.data().progress ?? 0,
+          lastTrained: d.data().lastTrained,
+        }))
+      );
+    } catch (e: any) {
+      setError(e.message ?? "Failed to load topics");
+    } finally {
+      setLoading(false);
+    }
+  }, [user, workspaceId]);
+
+  useEffect(() => {
+    setTopics([]); // reset on workspace change
+    void refetch();
+  }, [refetch]);
+
+  const addTopic = useCallback(
+    async (name: string) => {
+      if (!user || !workspaceId || !name.trim()) return;
+      const col = collection(
+        db,
+        "users",
+        user.uid,
+        "workspaces",
+        workspaceId,
+        "topics"
+      );
+      const docRef = await addDoc(col, {
+        name: name.trim(),
+        createdAt: serverTimestamp(),
+      });
+      setTopics((prev) => [...prev, { id: docRef.id, name: name.trim() }]);
+    },
+    [user, workspaceId]
+  );
+
+  const updateTopicProgress = useCallback(
+    async (topicId: string, percent: number) => {
+      if (!user || !workspaceId) return;
+      const topicRef = doc(
+        db,
+        "users",
+        user.uid,
+        "workspaces",
+        workspaceId,
+        "topics",
+        topicId
+      );
+      await updateDoc(topicRef, {
+        progress: percent,
+        lastTrained: serverTimestamp(),
+      });
+      // optimistic update
+      setTopics((prev) =>
+        prev.map((t) => (t.id === topicId ? { ...t, progress: percent } : t))
+      );
+    },
+    [user, workspaceId]
+  );
+
+  return { topics, loading, error, addTopic, updateTopicProgress, refetch };
+}

--- a/src/hooks/useWorkspaces.ts
+++ b/src/hooks/useWorkspaces.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  orderBy,
+  serverTimestamp,
+} from "firebase/firestore";
+import { db } from "../firebase";
+import { useUser } from "./useUser";
+import type { Workspace } from "../types/models";
+
+export function useWorkspaces() {
+  const { user } = useUser();
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const q = query(
+        collection(db, "users", user.uid, "workspaces"),
+        orderBy("createdAt", "asc")
+      );
+      const snap = await getDocs(q);
+      setWorkspaces(
+        snap.docs.map((d) => ({
+          id: d.id,
+          name: d.data().name,
+          createdAt: d.data().createdAt,
+        }))
+      );
+    } catch (e: any) {
+      setError(e.message ?? "Failed to load workspaces");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  const addWorkspace = useCallback(
+    async (name: string) => {
+      if (!user || !name.trim()) return;
+      const col = collection(db, "users", user.uid, "workspaces");
+      const docRef = await addDoc(col, {
+        name: name.trim(),
+        createdAt: serverTimestamp(),
+      });
+      // optimistic update
+      setWorkspaces((prev) => [...prev, { id: docRef.id, name: name.trim() }]);
+    },
+    [user]
+  );
+
+  return { workspaces, loading, error, addWorkspace, refetch };
+}

--- a/src/hooks/useWorkspaces.ts
+++ b/src/hooks/useWorkspaces.ts
@@ -6,11 +6,18 @@ import {
   query,
   orderBy,
   serverTimestamp,
+  doc,
+  updateDoc,
+  deleteDoc,
 } from "firebase/firestore";
 import { db } from "../firebase";
 import { useUser } from "./useUser";
 import type { Workspace } from "../types/models";
 
+/**
+ * Хук для списка рабочих пространств пользователя.
+ * CRUD: load, add, updateName, delete (с каскадным удалением подколлекций).
+ */
 export function useWorkspaces() {
   const { user } = useUser();
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
@@ -53,11 +60,68 @@ export function useWorkspaces() {
         name: name.trim(),
         createdAt: serverTimestamp(),
       });
-      // optimistic update
       setWorkspaces((prev) => [...prev, { id: docRef.id, name: name.trim() }]);
     },
     [user]
   );
 
-  return { workspaces, loading, error, addWorkspace, refetch };
+  const updateWorkspaceName = useCallback(
+    async (workspaceId: string, name: string) => {
+      if (!user || !workspaceId || !name.trim()) return;
+      const wsRef = doc(db, "users", user.uid, "workspaces", workspaceId);
+      await updateDoc(wsRef, { name: name.trim() });
+      setWorkspaces((prev) =>
+        prev.map((w) =>
+          w.id === workspaceId ? { ...w, name: name.trim() } : w
+        )
+      );
+    },
+    [user]
+  );
+
+  /**
+   * Удаление workspace + всех его topics и cards (простая каскадная чистка).
+   * Для больших коллекций лучше Cloud Functions или Firebase CLI recursive-delete.
+   */
+  const deleteWorkspace = useCallback(
+    async (workspaceId: string) => {
+      if (!user || !workspaceId) return;
+      // удалить все topics и их cards
+      const topicsSnap = await getDocs(
+        collection(db, "users", user.uid, "workspaces", workspaceId, "topics")
+      );
+      for (const topicDoc of topicsSnap.docs) {
+        // удалить все cards в каждой теме
+        const cardsSnap = await getDocs(
+          collection(
+            db,
+            "users",
+            user.uid,
+            "workspaces",
+            workspaceId,
+            "topics",
+            topicDoc.id,
+            "cards"
+          )
+        );
+        await Promise.all(cardsSnap.docs.map((c) => deleteDoc(c.ref)));
+        // затем удалить сам topic
+        await deleteDoc(topicDoc.ref);
+      }
+      // удалить сам workspace
+      await deleteDoc(doc(db, "users", user.uid, "workspaces", workspaceId));
+      setWorkspaces((prev) => prev.filter((w) => w.id !== workspaceId));
+    },
+    [user]
+  );
+
+  return {
+    workspaces,
+    loading,
+    error,
+    refetch,
+    addWorkspace,
+    updateWorkspaceName,
+    deleteWorkspace,
+  };
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,103 +1,40 @@
-// src/pages/Dashboard.tsx
-import { useEffect, useState } from "react";
-import { db } from "../firebase";
-import { collection, getDocs, addDoc } from "firebase/firestore";
-import { useUser } from "../hooks/useUser";
+import { useState } from "react";
+import { useWorkspaces } from "../hooks/useWorkspaces";
+import { useTopics } from "../hooks/useTopics";
+import { useCards } from "../hooks/useCards";
 
 import WorkspaceList from "../components/dashboard/workspace/WorkspaceList";
 import TopicList from "../components/dashboard/topic/TopicList";
 import CardList from "../components/dashboard/crds/CardList";
 
-type Workspace = { id: string; name: string };
-type Topic = { id: string; name: string };
-type Card = { id: string; front: string; back: string };
-
 export default function Dashboard() {
-    const { user } = useUser();
-
-    // State
-    const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-    const [topics, setTopics] = useState<Topic[]>([]);
-    const [cards, setCards] = useState<Card[]>([]);
-
+    // selections
     const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
     const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
 
+    // forms
     const [wsName, setWsName] = useState("");
     const [topicName, setTopicName] = useState("");
     const [front, setFront] = useState("");
     const [back, setBack] = useState("");
 
-    // Fetch workspaces
-    useEffect(() => {
-        if (!user) return;
-        (async () => {
-            const snap = await getDocs(collection(db, "users", user.uid, "workspaces"));
-            setWorkspaces(snap.docs.map(d => ({ id: d.id, name: d.data().name })));
-        })();
-    }, [user]);
+    // data via hooks
+    const { workspaces, addWorkspace } = useWorkspaces();
+    const { topics, addTopic } = useTopics(selectedWorkspaceId);
+    const { cards, addCard } = useCards(selectedWorkspaceId, selectedTopicId);
 
-    // Fetch topics
-    useEffect(() => {
-        if (!user || !selectedWorkspaceId) return;
-        (async () => {
-            const snap = await getDocs(
-                collection(db, "users", user.uid, "workspaces", selectedWorkspaceId, "topics")
-            );
-            setTopics(snap.docs.map(d => ({ id: d.id, name: d.data().name })));
-        })();
-        setSelectedTopicId(null);
-    }, [user, selectedWorkspaceId]);
-
-    // Fetch cards
-    useEffect(() => {
-        if (!user || !selectedWorkspaceId || !selectedTopicId) return;
-        (async () => {
-            const snap = await getDocs(
-                collection(
-                    db,
-                    "users", user.uid,
-                    "workspaces", selectedWorkspaceId,
-                    "topics", selectedTopicId,
-                    "cards"
-                )
-            );
-            setCards(snap.docs.map(d => ({
-                id: d.id,
-                front: d.data().front,
-                back: d.data().back,
-            })));
-        })();
-    }, [user, selectedWorkspaceId, selectedTopicId]);
-
-    // Handlers
     const handleAddWorkspace = async () => {
-        if (!wsName.trim() || !user) return;
-        const ref = collection(db, "users", user.uid, "workspaces");
-        const doc = await addDoc(ref, { name: wsName.trim() });
-        setWorkspaces(prev => [...prev, { id: doc.id, name: wsName.trim() }]);
+        await addWorkspace(wsName);
         setWsName("");
     };
 
     const handleAddTopic = async () => {
-        if (!topicName.trim() || !user || !selectedWorkspaceId) return;
-        const ref = collection(db, "users", user.uid, "workspaces", selectedWorkspaceId, "topics");
-        const doc = await addDoc(ref, { name: topicName.trim() });
-        setTopics(prev => [...prev, { id: doc.id, name: topicName.trim() }]);
+        await addTopic(topicName);
         setTopicName("");
     };
 
     const handleAddCard = async () => {
-        if (!front.trim() || !back.trim() || !user || !selectedWorkspaceId || !selectedTopicId) return;
-        const ref = collection(
-            db,
-            "users", user.uid,
-            "workspaces", selectedWorkspaceId,
-            "topics", selectedTopicId,
-            "cards"
-        );
-        const doc = await addDoc(ref, { front: front.trim(), back: back.trim() });
-        setCards(prev => [...prev, { id: doc.id, front: front.trim(), back: back.trim() }]);
+        await addCard(front, back);
         setFront("");
         setBack("");
     };

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,36 +8,17 @@ import TopicList from "../components/dashboard/topic/TopicList";
 import CardList from "../components/dashboard/crds/CardList";
 
 export default function Dashboard() {
-    // selections
     const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
     const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
 
-    // forms
     const [wsName, setWsName] = useState("");
     const [topicName, setTopicName] = useState("");
     const [front, setFront] = useState("");
     const [back, setBack] = useState("");
 
-    // data via hooks
-    const { workspaces, addWorkspace } = useWorkspaces();
-    const { topics, addTopic } = useTopics(selectedWorkspaceId);
-    const { cards, addCard } = useCards(selectedWorkspaceId, selectedTopicId);
-
-    const handleAddWorkspace = async () => {
-        await addWorkspace(wsName);
-        setWsName("");
-    };
-
-    const handleAddTopic = async () => {
-        await addTopic(topicName);
-        setTopicName("");
-    };
-
-    const handleAddCard = async () => {
-        await addCard(front, back);
-        setFront("");
-        setBack("");
-    };
+    const { workspaces, addWorkspace, updateWorkspaceName, deleteWorkspace } = useWorkspaces();
+    const { topics, addTopic, updateTopicName, deleteTopic } = useTopics(selectedWorkspaceId);
+    const { cards, addCard, updateCard, deleteCard } = useCards(selectedWorkspaceId, selectedTopicId);
 
     return (
         <div className="p-4 max-w-2xl mx-auto space-y-6">
@@ -46,16 +27,27 @@ export default function Dashboard() {
                     workspaces={workspaces}
                     newName={wsName}
                     onNameChange={setWsName}
-                    onAdd={handleAddWorkspace}
+                    onAdd={async () => { await addWorkspace(wsName); setWsName(""); }}
                     onSelect={setSelectedWorkspaceId}
+                    onRename={updateWorkspaceName}
+                    onDelete={async (id) => {
+                        // если удаляем выбранный — сброс
+                        if (selectedWorkspaceId === id) setSelectedWorkspaceId(null);
+                        await deleteWorkspace(id);
+                    }}
                 />
             ) : selectedTopicId === null ? (
                 <TopicList
                     topics={topics}
                     newName={topicName}
                     onNameChange={setTopicName}
-                    onAdd={handleAddTopic}
+                    onAdd={async () => { await addTopic(topicName); setTopicName(""); }}
                     onSelect={setSelectedTopicId}
+                    onRename={updateTopicName}
+                    onDelete={async (id) => {
+                        if (selectedTopicId === id) setSelectedTopicId(null);
+                        await deleteTopic(id);
+                    }}
                     onBack={() => setSelectedWorkspaceId(null)}
                 />
             ) : (
@@ -65,12 +57,11 @@ export default function Dashboard() {
                     back={back}
                     onFrontChange={setFront}
                     onBackChange={setBack}
-                    onAdd={handleAddCard}
+                    onAdd={async () => { await addCard(front, back); setFront(""); setBack(""); }}
+                    onUpdate={updateCard}
+                    onDelete={deleteCard}
                     onBackTopics={() => setSelectedTopicId(null)}
-                    onBackWorkspaces={() => {
-                        setSelectedTopicId(null);
-                        setSelectedWorkspaceId(null);
-                    }}
+                    onBackWorkspaces={() => { setSelectedTopicId(null); setSelectedWorkspaceId(null); }}
                 />
             )}
         </div>

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -1,0 +1,224 @@
+// src/pages/TrainingPage.tsx
+import { useEffect, useState } from "react";
+import { db } from "../firebase";
+import {
+    collection,
+    getDocs,
+    doc,
+    updateDoc,
+    serverTimestamp,
+} from "firebase/firestore";
+import { useUser } from "../hooks/useUser";
+import { useNavigate } from "react-router-dom";
+
+type Workspace = { id: string; name: string };
+type Topic = { id: string; name: string; progress?: number };
+type Card = { id: string; front: string; back: string };
+
+export default function Training() {
+    const { user } = useUser();
+    const navigate = useNavigate();
+
+    // 1. Выбор workspace и topic
+    const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+    const [topics, setTopics] = useState<Topic[]>([]);
+    const [stage, setStage] = useState<"selectWS" | "selectTopic" | "run" | "result">("selectWS");
+
+    const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+    const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
+
+    // 2. Данные карточек и прогресс
+    const [cards, setCards] = useState<Card[]>([]);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [flipped, setFlipped] = useState(false);
+    const [knownCount, setKnownCount] = useState(0);
+    const [answers, setAnswers] = useState<("know" | "dontKnow")[]>([]);
+
+    // 3. Fetch workspaces
+    useEffect(() => {
+        if (!user) return;
+        (async () => {
+            const snap = await getDocs(collection(db, "users", user.uid, "workspaces"));
+            setWorkspaces(snap.docs.map(d => ({ id: d.id, name: d.data().name })));
+        })();
+    }, [user]);
+
+    // 4. Fetch topics после выбора workspace
+    useEffect(() => {
+        if (!user || !selectedWorkspaceId) return;
+        (async () => {
+            const snap = await getDocs(
+                collection(db, "users", user.uid, "workspaces", selectedWorkspaceId, "topics")
+            );
+            setTopics(snap.docs.map(d => ({
+                id: d.id,
+                name: d.data().name,
+                progress: d.data().progress || 0
+            })));
+        })();
+    }, [user, selectedWorkspaceId]);
+
+    // 5. Подгрузка карточек при начале run
+    useEffect(() => {
+        if (stage !== "run" || !selectedWorkspaceId || !selectedTopicId || !user) return;
+        (async () => {
+            const snap = await getDocs(
+                collection(
+                    db,
+                    "users", user.uid,
+                    "workspaces", selectedWorkspaceId,
+                    "topics", selectedTopicId,
+                    "cards"
+                )
+            );
+            setCards(snap.docs.map(d => ({
+                id: d.id,
+                front: d.data().front,
+                back: d.data().back,
+            })));
+        })();
+    }, [stage, user, selectedWorkspaceId, selectedTopicId]);
+
+    // 6. Обработчики
+    const handleSelectWS = (id: string) => {
+        setSelectedWorkspaceId(id);
+        setStage("selectTopic");
+    };
+
+    const handleSelectTopic = (id: string) => {
+        setSelectedTopicId(id);
+        setStage("run");
+    };
+
+    const handleFlip = () => {
+        setFlipped(prev => !prev);
+    };
+
+    const handleAnswer = (ans: "know" | "dontKnow") => {
+        if (!user) return;
+        setAnswers(prev => [...prev, ans]);
+        if (ans === "know") setKnownCount(prev => prev + 1);
+        setFlipped(false);
+        if (currentIndex + 1 < cards.length) {
+            setCurrentIndex(prev => prev + 1);
+        } else {
+            setStage("result");
+            // сохраняем прогресс
+            (async () => {
+                const percent = Math.round((knownCount + (ans === "know" ? 1 : 0)) / cards.length * 100);
+                const topicRef = doc(
+                    db,
+                    "users", user.uid,
+                    "workspaces", selectedWorkspaceId!,
+                    "topics", selectedTopicId!
+                );
+                await updateDoc(topicRef, {
+                    progress: percent,
+                    lastTrained: serverTimestamp(),
+                });
+            })();
+        }
+    };
+
+    const handleBack = () => {
+        if (stage === "selectTopic") {
+            setStage("selectWS");
+            setSelectedWorkspaceId(null);
+        } else if (stage === "selectWS") {
+            navigate("/"); // вернуться на Dashboard
+        } else {
+            // выйти из тренировки на выбор тем
+            setStage("selectTopic");
+            setSelectedTopicId(null);
+        }
+    };
+
+    // 7. UI-рендеринг по стадиям
+    return (
+        <div className="p-4 max-w-2xl mx-auto">
+            {stage === "selectWS" && (
+                <>
+                    <h2 className="text-xl font-bold mb-4">Select Workspace</h2>
+                    <ul className="space-y-2">
+                        {workspaces.map(ws => (
+                            <li
+                                key={ws.id}
+                                className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
+                                onClick={() => handleSelectWS(ws.id)}
+                            >
+                                {ws.name}
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+
+            {stage === "selectTopic" && (
+                <>
+                    <button onClick={handleBack} className="text-sm text-blue-500 mb-2">
+                        ← Back
+                    </button>
+                    <h2 className="text-xl font-bold mb-4">Select Topic</h2>
+                    <ul className="space-y-2">
+                        {topics.map(t => (
+                            <li
+                                key={t.id}
+                                className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
+                                onClick={() => handleSelectTopic(t.id)}
+                            >
+                                {t.name} ({t.progress}%)
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+
+            {stage === "run" && cards.length > 0 && (
+                <>
+                    <button onClick={handleBack} className="text-sm text-blue-500 mb-2">
+                        ← Exit Training
+                    </button>
+                    <div
+                        className="p-6 border rounded mb-4 cursor-pointer select-none"
+                        onClick={handleFlip}
+                    >
+                        {flipped ? cards[currentIndex].back : cards[currentIndex].front}
+                    </div>
+                    <div className="flex gap-2">
+                        <button
+                            onClick={() => handleAnswer("dontKnow")}
+                            className="btn btn-outline flex-grow"
+                        >
+                            Don’t Know
+                        </button>
+                        <button
+                            onClick={() => handleAnswer("know")}
+                            className="btn btn-primary flex-grow"
+                        >
+                            Know
+                        </button>
+                    </div>
+                    <p className="text-center mt-2">
+                        Card {currentIndex + 1} of {cards.length}
+                    </p>
+                </>
+            )}
+
+            {stage === "result" && (
+                <>
+                    <h2 className="text-xl font-bold mb-4">Results</h2>
+                    <p>
+                        You knew {knownCount} out of {cards.length} cards (
+                        {Math.round((knownCount / cards.length) * 100)}%).
+                    </p>
+                    <button onClick={() => navigate("/training")} className="btn btn-primary mt-4">
+                        Try Another Topic
+                    </button>
+                    <button onClick={() => navigate("/")} className="btn btn-outline mt-2">
+                        Back to Dashboard
+                    </button>
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,0 +1,20 @@
+export type Workspace = {
+  id: string;
+  name: string;
+  createdAt?: any;
+};
+
+export type Topic = {
+  id: string;
+  name: string;
+  createdAt?: any;
+  progress?: number;
+  lastTrained?: any;
+};
+
+export type Card = {
+  id: string;
+  front: string;
+  back: string;
+  createdAt?: any;
+};


### PR DESCRIPTION
**Summary**
This PR introduces full **CRUD** support via data hooks and connects it to the UI.  
It also adds **minimal Firestore Security Rules** and moves Firebase web config into **environment variables**.

**What's changed**
**Data layer (hooks)**
- `useWorkspaces`: `addWorkspace`, `updateWorkspaceName`, `deleteWorkspace` (with cascade deletion of topics/cards)
- `useTopics`: `addTopic`, `updateTopicName`, `updateTopicProgress`, `deleteTopic` (deletes cards in the topic)
- `useCards`: `addCard`, `updateCard`, `deleteCard`
- All queries ordered by `createdAt`; all creates set `createdAt = serverTimestamp()`

**UI wiring**
- Updated components to accept CRUD callbacks:
  - `WorkspaceList/Item` → select, **rename**, **delete**
  - `TopicList/Item` → select, **rename**, **delete**
  - `CardList/Item` → **add**, **edit**, **delete**
- `Dashboard.tsx` is now a thin orchestrator: state + passing hook methods down to lists
