### PR TITLE
Training: persist per-card results (know/dont know); add 'only unknow…

### DIFF
--- a/src/components/dashboard/crds/CardItem.tsx
+++ b/src/components/dashboard/crds/CardItem.tsx
@@ -1,13 +1,46 @@
+import { useState } from "react";
+
 type Props = {
+    id: string;
     front: string;
     back: string;
+    onUpdate: (id: string, updates: { front?: string; back?: string }) => void;
+    onDelete: (id: string) => void;
 };
 
-export default function CardItem({ front, back }: Props) {
+export default function CardItem({ id, front, back, onUpdate, onDelete }: Props) {
+    const [editing, setEditing] = useState(false);
+    const [f, setF] = useState(front);
+    const [b, setB] = useState(back);
+
     return (
         <li className="p-2 border rounded">
-            <strong>{front}</strong> → {back}
+            {!editing ? (
+                <div className="flex items-center justify-between">
+                    <div>
+                        <strong>{front}</strong> → {back}
+                    </div>
+                    <div className="flex gap-2">
+                        <button className="btn btn-xs" onClick={() => { setF(front); setB(back); setEditing(true); }}>
+                            Edit
+                        </button>
+                        <button className="btn btn-xs btn-error" onClick={() => onDelete(id)}>
+                            Delete
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <div className="space-y-2">
+                    <input className="input input-bordered input-sm w-full" value={f} onChange={(e) => setF(e.target.value)} />
+                    <input className="input input-bordered input-sm w-full" value={b} onChange={(e) => setB(e.target.value)} />
+                    <div className="flex gap-2">
+                        <button className="btn btn-xs btn-primary" onClick={() => { onUpdate(id, { front: f, back: b }); setEditing(false); }}>
+                            Save
+                        </button>
+                        <button className="btn btn-xs" onClick={() => setEditing(false)}>Cancel</button>
+                    </div>
+                </div>
+            )}
         </li>
     );
 }
-

--- a/src/components/dashboard/crds/CardList.tsx
+++ b/src/components/dashboard/crds/CardList.tsx
@@ -9,51 +9,49 @@ type Props = {
     onFrontChange: (s: string) => void;
     onBackChange: (s: string) => void;
     onAdd: () => void;
+    onUpdate: (id: string, updates: { front?: string; back?: string }) => void;
+    onDelete: (id: string) => void;
     onBackTopics: () => void;
     onBackWorkspaces: () => void;
 };
 
 export default function CardList({
-    cards,
-    front,
-    back,
-    onFrontChange,
-    onBackChange,
-    onAdd,
-    onBackTopics,
-    onBackWorkspaces,
+    cards, front, back, onFrontChange, onBackChange, onAdd, onUpdate, onDelete, onBackTopics, onBackWorkspaces
 }: Props) {
     return (
         <>
             <div className="flex items-center gap-4 mb-2">
-                <button className="text-sm text-blue-500" onClick={onBackTopics}>
-                    ← Back to Topics
-                </button>
-                <button className="text-sm text-blue-500" onClick={onBackWorkspaces}>
-                    ← Back to Workspaces
-                </button>
+                <button className="text-sm text-blue-500" onClick={onBackTopics}>← Back to Topics</button>
+                <button className="text-sm text-blue-500" onClick={onBackWorkspaces}>← Back to Workspaces</button>
             </div>
+
             <h2 className="text-2xl font-bold">Flashcards</h2>
             <div className="space-y-2 mb-4">
                 <input
                     value={front}
-                    onChange={e => onFrontChange(e.target.value)}
+                    onChange={(e) => onFrontChange(e.target.value)}
                     placeholder="Front text"
                     className="input input-bordered w-full"
                 />
                 <input
                     value={back}
-                    onChange={e => onBackChange(e.target.value)}
+                    onChange={(e) => onBackChange(e.target.value)}
                     placeholder="Back text"
                     className="input input-bordered w-full"
                 />
-                <button onClick={onAdd} className="btn btn-primary w-full">
-                    Add Card
-                </button>
+                <button onClick={onAdd} className="btn btn-primary w-full">Add Card</button>
             </div>
+
             <ul className="space-y-2">
-                {cards.map(c => (
-                    <CardItem key={c.id} front={c.front} back={c.back} />
+                {cards.map((c) => (
+                    <CardItem
+                        key={c.id}
+                        id={c.id}
+                        front={c.front}
+                        back={c.back}
+                        onUpdate={onUpdate}
+                        onDelete={onDelete}
+                    />
                 ))}
             </ul>
         </>

--- a/src/components/dashboard/topic/TopicItem.tsx
+++ b/src/components/dashboard/topic/TopicItem.tsx
@@ -1,16 +1,44 @@
+import { useState } from "react";
+
 type Props = {
     id: string;
     name: string;
     onSelect: (id: string) => void;
+    onRename: (id: string, newName: string) => void;
+    onDelete: (id: string) => void;
 };
 
-export default function TopicItem({ id, name, onSelect }: Props) {
+export default function TopicItem({ id, name, onSelect, onRename, onDelete }: Props) {
+    const [editing, setEditing] = useState(false);
+    const [value, setValue] = useState(name);
+
     return (
-        <li
-            className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
-            onClick={() => onSelect(id)}
-        >
-            {name}
+        <li className="p-2 border rounded hover:bg-gray-100">
+            {!editing ? (
+                <div className="flex items-center justify-between">
+                    <span className="cursor-pointer" onClick={() => onSelect(id)}>{name}</span>
+                    <div className="flex gap-2">
+                        <button className="btn btn-xs" onClick={() => { setValue(name); setEditing(true); }}>
+                            Edit
+                        </button>
+                        <button className="btn btn-xs btn-error" onClick={() => onDelete(id)}>
+                            Delete
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <div className="flex items-center gap-2">
+                    <input
+                        className="input input-bordered input-sm flex-grow"
+                        value={value}
+                        onChange={(e) => setValue(e.target.value)}
+                    />
+                    <button className="btn btn-xs btn-primary" onClick={() => { onRename(id, value); setEditing(false); }}>
+                        Save
+                    </button>
+                    <button className="btn btn-xs" onClick={() => setEditing(false)}>Cancel</button>
+                </div>
+            )}
         </li>
     );
 }

--- a/src/components/dashboard/topic/TopicList.tsx
+++ b/src/components/dashboard/topic/TopicList.tsx
@@ -8,40 +8,40 @@ type Props = {
     onNameChange: (s: string) => void;
     onAdd: () => void;
     onSelect: (id: string) => void;
+    onRename: (id: string, newName: string) => void;
+    onDelete: (id: string) => void;
     onBack: () => void;
 };
 
 export default function TopicList({
-    topics,
-    newName,
-    onNameChange,
-    onAdd,
-    onSelect,
-    onBack,
+    topics, newName, onNameChange, onAdd, onSelect, onRename, onDelete, onBack
 }: Props) {
     return (
         <>
-            <button
-                className="text-sm text-blue-500 mb-2"
-                onClick={onBack}
-            >
+            <button className="text-sm text-blue-500 mb-2" onClick={onBack}>
                 ← Back to Workspaces
             </button>
             <h2 className="text-2xl font-bold">Topics</h2>
             <div className="flex gap-2">
                 <input
                     value={newName}
-                    onChange={e => onNameChange(e.target.value)}
+                    onChange={(e) => onNameChange(e.target.value)}
                     placeholder="New topic"
                     className="input input-bordered flex-grow"
                 />
-                <button onClick={onAdd} className="btn btn-primary">
-                    Add
-                </button>
+                <button onClick={onAdd} className="btn btn-primary">Add</button>
             </div>
+
             <ul className="mt-4 space-y-2">
-                {topics.map(t => (
-                    <TopicItem key={t.id} id={t.id} name={t.name} onSelect={onSelect} />
+                {topics.map((t) => (
+                    <TopicItem
+                        key={t.id}
+                        id={t.id}
+                        name={t.name}
+                        onSelect={onSelect}
+                        onRename={onRename}
+                        onDelete={onDelete}
+                    />
                 ))}
             </ul>
         </>

--- a/src/components/dashboard/workspace/WorkspaceItem.tsx
+++ b/src/components/dashboard/workspace/WorkspaceItem.tsx
@@ -1,16 +1,49 @@
+import { useState } from "react";
+
 type Props = {
     id: string;
     name: string;
     onSelect: (id: string) => void;
+    onRename: (id: string, newName: string) => void;
+    onDelete: (id: string) => void;
 };
 
-export default function WorkspaceItem({ id, name, onSelect }: Props) {
+export default function WorkspaceItem({ id, name, onSelect, onRename, onDelete }: Props) {
+    const [editing, setEditing] = useState(false);
+    const [value, setValue] = useState(name);
+
     return (
-        <li
-            className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
-            onClick={() => onSelect(id)}
-        >
-            {name}
+        <li className="p-2 border rounded hover:bg-gray-100">
+            {!editing ? (
+                <div className="flex items-center justify-between">
+                    <span className="cursor-pointer" onClick={() => onSelect(id)}>{name}</span>
+                    <div className="flex gap-2">
+                        <button className="btn btn-xs" onClick={() => { setValue(name); setEditing(true); }}>
+                            Edit
+                        </button>
+                        <button className="btn btn-xs btn-error" onClick={() => onDelete(id)}>
+                            Delete
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <div className="flex items-center gap-2">
+                    <input
+                        className="input input-bordered input-sm flex-grow"
+                        value={value}
+                        onChange={(e) => setValue(e.target.value)}
+                    />
+                    <button
+                        className="btn btn-xs btn-primary"
+                        onClick={() => { onRename(id, value); setEditing(false); }}
+                    >
+                        Save
+                    </button>
+                    <button className="btn btn-xs" onClick={() => setEditing(false)}>
+                        Cancel
+                    </button>
+                </div>
+            )}
         </li>
     );
 }

--- a/src/components/dashboard/workspace/WorkspaceList.tsx
+++ b/src/components/dashboard/workspace/WorkspaceList.tsx
@@ -8,14 +8,12 @@ type Props = {
     onNameChange: (s: string) => void;
     onAdd: () => void;
     onSelect: (id: string) => void;
+    onRename: (id: string, newName: string) => void;
+    onDelete: (id: string) => void;
 };
 
 export default function WorkspaceList({
-    workspaces,
-    newName,
-    onNameChange,
-    onAdd,
-    onSelect,
+    workspaces, newName, onNameChange, onAdd, onSelect, onRename, onDelete
 }: Props) {
     return (
         <>
@@ -23,21 +21,22 @@ export default function WorkspaceList({
             <div className="flex gap-2">
                 <input
                     value={newName}
-                    onChange={e => onNameChange(e.target.value)}
+                    onChange={(e) => onNameChange(e.target.value)}
                     placeholder="New workspace"
                     className="input input-bordered flex-grow"
                 />
-                <button onClick={onAdd} className="btn btn-primary">
-                    Add
-                </button>
+                <button onClick={onAdd} className="btn btn-primary">Add</button>
             </div>
+
             <ul className="mt-4 space-y-2">
-                {workspaces.map(ws => (
+                {workspaces.map((ws) => (
                     <WorkspaceItem
                         key={ws.id}
                         id={ws.id}
                         name={ws.name}
                         onSelect={onSelect}
+                        onRename={onRename}
+                        onDelete={onDelete}
                     />
                 ))}
             </ul>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,36 +8,17 @@ import TopicList from "../components/dashboard/topic/TopicList";
 import CardList from "../components/dashboard/crds/CardList";
 
 export default function Dashboard() {
-    // selections
     const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
     const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
 
-    // forms
     const [wsName, setWsName] = useState("");
     const [topicName, setTopicName] = useState("");
     const [front, setFront] = useState("");
     const [back, setBack] = useState("");
 
-    // data via hooks
-    const { workspaces, addWorkspace } = useWorkspaces();
-    const { topics, addTopic } = useTopics(selectedWorkspaceId);
-    const { cards, addCard } = useCards(selectedWorkspaceId, selectedTopicId);
-
-    const handleAddWorkspace = async () => {
-        await addWorkspace(wsName);
-        setWsName("");
-    };
-
-    const handleAddTopic = async () => {
-        await addTopic(topicName);
-        setTopicName("");
-    };
-
-    const handleAddCard = async () => {
-        await addCard(front, back);
-        setFront("");
-        setBack("");
-    };
+    const { workspaces, addWorkspace, updateWorkspaceName, deleteWorkspace } = useWorkspaces();
+    const { topics, addTopic, updateTopicName, deleteTopic } = useTopics(selectedWorkspaceId);
+    const { cards, addCard, updateCard, deleteCard } = useCards(selectedWorkspaceId, selectedTopicId);
 
     return (
         <div className="p-4 max-w-2xl mx-auto space-y-6">
@@ -46,16 +27,27 @@ export default function Dashboard() {
                     workspaces={workspaces}
                     newName={wsName}
                     onNameChange={setWsName}
-                    onAdd={handleAddWorkspace}
+                    onAdd={async () => { await addWorkspace(wsName); setWsName(""); }}
                     onSelect={setSelectedWorkspaceId}
+                    onRename={updateWorkspaceName}
+                    onDelete={async (id) => {
+                        // если удаляем выбранный — сброс
+                        if (selectedWorkspaceId === id) setSelectedWorkspaceId(null);
+                        await deleteWorkspace(id);
+                    }}
                 />
             ) : selectedTopicId === null ? (
                 <TopicList
                     topics={topics}
                     newName={topicName}
                     onNameChange={setTopicName}
-                    onAdd={handleAddTopic}
+                    onAdd={async () => { await addTopic(topicName); setTopicName(""); }}
                     onSelect={setSelectedTopicId}
+                    onRename={updateTopicName}
+                    onDelete={async (id) => {
+                        if (selectedTopicId === id) setSelectedTopicId(null);
+                        await deleteTopic(id);
+                    }}
                     onBack={() => setSelectedWorkspaceId(null)}
                 />
             ) : (
@@ -65,12 +57,11 @@ export default function Dashboard() {
                     back={back}
                     onFrontChange={setFront}
                     onBackChange={setBack}
-                    onAdd={handleAddCard}
+                    onAdd={async () => { await addCard(front, back); setFront(""); setBack(""); }}
+                    onUpdate={updateCard}
+                    onDelete={deleteCard}
                     onBackTopics={() => setSelectedTopicId(null)}
-                    onBackWorkspaces={() => {
-                        setSelectedTopicId(null);
-                        setSelectedWorkspaceId(null);
-                    }}
+                    onBackWorkspaces={() => { setSelectedTopicId(null); setSelectedWorkspaceId(null); }}
                 />
             )}
         </div>

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -1,84 +1,106 @@
-import { useEffect, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useWorkspaces } from "../hooks/useWorkspaces";
 import { useTopics } from "../hooks/useTopics";
 import { useCards } from "../hooks/useCards";
 
 type Stage = "selectWS" | "selectTopic" | "run" | "result";
+type Answer = "know" | "dontKnow";
 
-export default function TrainingPage() {
+export default function Training() {
     const navigate = useNavigate();
 
-    // selections
     const [stage, setStage] = useState<Stage>("selectWS");
     const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
     const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
 
-    // data via hooks
+    const [shuffle, setShuffle] = useState(true);
+    const [onlyUnknown, setOnlyUnknown] = useState(false);
+
     const { workspaces } = useWorkspaces();
     const { topics, updateTopicProgress } = useTopics(selectedWorkspaceId);
-    const { cards } = useCards(selectedWorkspaceId, selectedTopicId);
+    const { cards, setCardResult } = useCards(selectedWorkspaceId, selectedTopicId);
 
-    // run state
+    const allIds = useMemo(() => cards.map(c => c.id), [cards]);
+
+    const [queue, setQueue] = useState<string[]>([]);
     const [currentIndex, setCurrentIndex] = useState(0);
     const [flipped, setFlipped] = useState(false);
-    const [knownCount, setKnownCount] = useState(0);
 
-    // reset run when cards loaded
-    useEffect(() => {
-        if (stage === "run") {
-            setCurrentIndex(0);
-            setFlipped(false);
-            setKnownCount(0);
-        }
-    }, [stage, selectedWorkspaceId, selectedTopicId]);
+    const lastAnswerByCard = useRef<Record<string, Answer | undefined>>({});
+    const actionStack = useRef<{ cardId: string; prev: Answer | undefined }[]>([]);
+
+    const currentCard = useMemo(() => {
+        const id = queue[currentIndex];
+        return cards.find(c => c.id === id) || null;
+    }, [queue, currentIndex, cards]);
 
     const handleSelectWS = (id: string) => {
         setSelectedWorkspaceId(id);
+        setSelectedTopicId(null);
         setStage("selectTopic");
     };
 
     const handleSelectTopic = (id: string) => {
         setSelectedTopicId(id);
+    };
+
+    const handleStart = () => {
+        if (!selectedWorkspaceId || !selectedTopicId) return;
+        let ids = onlyUnknown ? cards.filter(c => c.lastResult === "dontKnow").map(c => c.id) : allIds;
+        if (shuffle) fisherYates(ids);
+        lastAnswerByCard.current = {};
+        actionStack.current = [];
+        setQueue(ids);
+        setCurrentIndex(0);
+        setFlipped(false);
         setStage("run");
     };
 
-    const handleFlip = () => setFlipped(p => !p);
+    const handleFlip = () => setFlipped(f => !f);
 
-    const handleAnswer = async (ans: "know" | "dontKnow") => {
-        const nextKnown = knownCount + (ans === "know" ? 1 : 0);
+    const handleAnswer = async (ans: Answer) => {
+        if (!queue.length || !currentCard) return;
+        const cardId = currentCard.id;
+        const prev = lastAnswerByCard.current[cardId];
+        actionStack.current.push({ cardId, prev });
+        lastAnswerByCard.current[cardId] = ans;
+        await setCardResult(cardId, ans); // пишем статус в Firestore сразу
 
-        if (currentIndex + 1 < cards.length) {
-            setKnownCount(nextKnown);
+        const atLast = currentIndex + 1 >= queue.length;
+        if (!atLast) {
             setCurrentIndex(i => i + 1);
             setFlipped(false);
             return;
         }
 
-        // finish
-        setKnownCount(nextKnown);
+        // считаем прогресс по всему топику: ответ из сессии перекрывает старый lastResult
+        const knownNow = cards.reduce((acc, c) => {
+            const final = lastAnswerByCard.current[c.id] ?? c.lastResult;
+            return acc + (final === "know" ? 1 : 0);
+        }, 0);
+        const percent = cards.length ? Math.round((knownNow / cards.length) * 100) : 0;
+        if (selectedTopicId) await updateTopicProgress(selectedTopicId, percent);
         setStage("result");
-
-        // persist progress
-        if (selectedWorkspaceId && selectedTopicId && cards.length > 0) {
-            const percent = Math.round((nextKnown / cards.length) * 100);
-            await updateTopicProgress(selectedTopicId, percent);
-        }
     };
 
-    const handleBack = () => {
-        if (stage === "selectTopic") {
-            setStage("selectWS");
-            setSelectedWorkspaceId(null);
-        } else if (stage === "selectWS") {
-            navigate("/");
-        } else {
-            setStage("selectTopic");
-            setSelectedTopicId(null);
-        }
+    const handleUndo = () => {
+        if (!actionStack.current.length || currentIndex === 0) return;
+        const last = actionStack.current.pop()!;
+        lastAnswerByCard.current[last.cardId] = last.prev;
+        setCurrentIndex(i => i - 1);
+        setFlipped(false);
     };
 
-    // minimal UI (same as before)
+    const handleExitRun = () => {
+        setStage("selectTopic");
+        setQueue([]);
+        setCurrentIndex(0);
+        setFlipped(false);
+        lastAnswerByCard.current = {};
+        actionStack.current = [];
+    };
+
     return (
         <div className="p-4 max-w-2xl mx-auto">
             {stage === "selectWS" && (
@@ -86,11 +108,7 @@ export default function TrainingPage() {
                     <h2 className="text-xl font-bold mb-4">Select Workspace</h2>
                     <ul className="space-y-2">
                         {workspaces.map(ws => (
-                            <li
-                                key={ws.id}
-                                className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
-                                onClick={() => handleSelectWS(ws.id)}
-                            >
+                            <li key={ws.id} className="p-2 border rounded hover:bg-gray-100 cursor-pointer" onClick={() => handleSelectWS(ws.id)}>
                                 {ws.name}
                             </li>
                         ))}
@@ -100,61 +118,97 @@ export default function TrainingPage() {
 
             {stage === "selectTopic" && (
                 <>
-                    <button onClick={handleBack} className="text-sm text-blue-500 mb-2">
-                        ← Back
-                    </button>
-                    <h2 className="text-xl font-bold mb-4">Select Topic</h2>
-                    <ul className="space-y-2">
+                    <button onClick={() => { setStage("selectWS"); setSelectedWorkspaceId(null); setSelectedTopicId(null); }} className="text-sm text-blue-500 mb-2">← Back</button>
+                    <h2 className="text-xl font-bold mb-2">Select Topic</h2>
+                    <ul className="space-y-2 mb-4">
                         {topics.map(t => (
                             <li
                                 key={t.id}
-                                className="p-2 border rounded hover:bg-gray-100 cursor-pointer"
+                                className={`p-2 border rounded cursor-pointer hover:bg-gray-100 ${selectedTopicId === t.id ? "bg-gray-100" : ""}`}
                                 onClick={() => handleSelectTopic(t.id)}
                             >
                                 {t.name} ({t.progress ?? 0}%)
                             </li>
                         ))}
                     </ul>
+
+                    {selectedTopicId && (
+                        <div className="border rounded p-3 space-y-3">
+                            <div className="flex items-center gap-4">
+                                <label className="flex items-center gap-2 cursor-pointer">
+                                    <input type="checkbox" checked={shuffle} onChange={(e) => setShuffle(e.target.checked)} />
+                                    <span>Shuffle cards</span>
+                                </label>
+                                <label className="flex items-center gap-2 cursor-pointer">
+                                    <input type="checkbox" checked={onlyUnknown} onChange={(e) => setOnlyUnknown(e.target.checked)} />
+                                    <span>Only unknown from last time</span>
+                                </label>
+                            </div>
+                            <div className="flex gap-2">
+                                <button className="btn btn-primary" onClick={handleStart}>Start Training</button>
+                                <button className="btn" onClick={() => setSelectedTopicId(null)}>Change topic</button>
+                            </div>
+                        </div>
+                    )}
                 </>
             )}
 
-            {stage === "run" && cards.length > 0 && (
+            {stage === "run" && queue.length > 0 && currentCard && (
                 <>
-                    <button onClick={handleBack} className="text-sm text-blue-500 mb-2">
-                        ← Exit Training
-                    </button>
-                    <div className="p-6 border rounded mb-4 cursor-pointer select-none" onClick={handleFlip}>
-                        {flipped ? cards[currentIndex].back : cards[currentIndex].front}
+                    <div className="flex items-center justify-between mb-2">
+                        <button onClick={handleExitRun} className="text-sm text-blue-500">← Exit Training</button>
+                        <button className="text-sm" disabled={currentIndex === 0} onClick={handleUndo} title="Undo">⟲ Undo</button>
                     </div>
+
+                    <div className="p-6 border rounded mb-4 cursor-pointer select-none min-h-[120px] flex items-center justify-center text-center" onClick={handleFlip}>
+                        {flipped ? currentCard.back : currentCard.front}
+                    </div>
+
                     <div className="flex gap-2">
-                        <button onClick={() => handleAnswer("dontKnow")} className="btn btn-outline flex-grow">
-                            Don’t Know
-                        </button>
-                        <button onClick={() => handleAnswer("know")} className="btn btn-primary flex-grow">
-                            Know
-                        </button>
+                        <button onClick={() => handleAnswer("dontKnow")} className="btn btn-outline flex-grow">Don’t Know</button>
+                        <button onClick={() => handleAnswer("know")} className="btn btn-primary flex-grow">Know</button>
                     </div>
-                    <p className="text-center mt-2">
-                        Card {currentIndex + 1} of {cards.length}
-                    </p>
+
+                    <p className="text-center mt-2">Card {currentIndex + 1} of {queue.length}</p>
                 </>
+            )}
+
+            {stage === "run" && queue.length === 0 && (
+                <div className="space-y-3">
+                    <p>No cards to train with current filter.</p>
+                    <button className="btn" onClick={() => setStage("selectTopic")}>Back</button>
+                </div>
             )}
 
             {stage === "result" && (
                 <>
                     <h2 className="text-xl font-bold mb-4">Results</h2>
-                    <p>
-                        You knew {knownCount} out of {cards.length} cards (
-                        {cards.length ? Math.round((knownCount / cards.length) * 100) : 0}%).
-                    </p>
-                    <button onClick={() => window.location.assign("/training")} className="btn btn-primary mt-4">
-                        Try Another Topic
-                    </button>
-                    <button onClick={() => navigate("/")} className="btn btn-outline mt-2">
-                        Back to Dashboard
-                    </button>
+                    <Result ids={queue} last={lastAnswerByCard.current} />
+                    <div className="mt-4 flex gap-2">
+                        <button onClick={() => navigate("/training")} className="btn btn-primary">Train Another Topic</button>
+                        <button onClick={() => navigate("/")} className="btn btn-outline">Back to Dashboard</button>
+                    </div>
                 </>
             )}
         </div>
     );
+}
+
+function fisherYates<T>(arr: T[]) {
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = (Math.random() * (i + 1)) | 0;
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+}
+
+function computeResult(ids: string[], last: Record<string, Answer | undefined>) {
+    let known = 0;
+    for (const id of ids) if (last[id] === "know") known++;
+    return { known, total: ids.length };
+}
+
+function Result({ ids, last }: { ids: string[]; last: Record<string, Answer | undefined> }) {
+    const { known, total } = computeResult(ids, last);
+    const percent = total ? Math.round((known / total) * 100) : 0;
+    return <p>You knew <strong>{known}</strong> out of <strong>{total}</strong> cards (<strong>{percent}%</strong>).</p>;
 }

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -17,4 +17,8 @@ export type Card = {
   front: string;
   back: string;
   createdAt?: any;
+  lastResult?: "know" | "dontKnow";
+  seenCount?: number;
+  knownCount?: number;
+  lastAnsweredAt?: any;
 };


### PR DESCRIPTION
**Summary**
This PR upgrades the training flow to **persist per-card results** and introduces an **“Only unknown from last time”** mode. The previous repeat-pass logic is removed for a simpler UX.

**What’s changed**
- `Training.tsx`
  - New toggle: **Only unknown from last time** (builds the session queue from cards with `lastResult: "dontKnow"`).
  - Writes per-card result to Firestore on each answer via `setCardResult`.
  - Final topic progress is computed from the latest per-card states.
  - Removed the old “repeat wrong” pass.
- `useCards.ts`
  - Added `setCardResult(cardId, "know" | "dontKnow")` that updates:
    - `lastResult`
    - `lastAnsweredAt` (server timestamp)
    - `seenCount` (increment)
    - `knownCount` (increment on “know”)
  - Read mapping returns these fields when present.
- `types/models.ts`
  - Extended `Card` with `lastResult`, `seenCount`, `knownCount`, `lastAnsweredAt`.

**Data model**
Each card document (under `users/{uid}/workspaces/{ws}/topics/{topic}/cards/{cardId}`) may now include:
```ts
{
  lastResult: "know" | "dontKnow" | null,
  seenCount: number,
  knownCount: number,
  lastAnsweredAt: Timestamp
}
